### PR TITLE
use output directory as input directory

### DIFF
--- a/processor/config.py
+++ b/processor/config.py
@@ -5,8 +5,17 @@ class Config:
     def __init__(self):
         self.ENVIRONMENT          = os.getenv('ENVIRONMENT', 'local')
 
-        self.INPUT_DIR            = os.getenv('INPUT_DIR')
-        self.OUTPUT_DIR           = os.getenv('OUTPUT_DIR')
+        if self.ENVIRONMENT == 'local':
+            self.INPUT_DIR            = os.getenv('INPUT_DIR')
+            self.OUTPUT_DIR           = os.getenv('OUTPUT_DIR')
+        else:
+            # workflow / analysis pipeline only supports 3 processors (pre-, main, post-)
+            # the output directory of the main processor is what the post-processor needs to read from
+            # so for now we will set the input directory for this processor to be the output directory variable
+            self.INPUT_DIR            = os.getenv('OUTPUT_DIR')
+            self.OUTPUT_DIR           = os.path.join(self.INPUT_DIR, "output")
+            if not os.path.exists(self.OUTPUT_DIR):
+                os.makedirs(self.OUTPUT_DIR)
 
         self.CHUNK_SIZE_MB        = int(os.getenv('CHUNK_SIZE_MB', '1'))
 


### PR DESCRIPTION
### Descriptions
Due to current limitations with the analysis / workflow pipeline, which is hard-configured for three processors (pre-, main, post), the post-processor needs to look at the output directory of the main processor to see the NWB file generated by the main processor.