### PR TITLE
store chunked binary sample data in uV

### DIFF
--- a/processor/timeseries_channel.py
+++ b/processor/timeseries_channel.py
@@ -1,4 +1,7 @@
 class TimeSeriesChannel:
+    # Unit is always microvolts - data is converted to uV during processing
+    UNIT = "uV"
+
     def __init__(
         self,
         index,
@@ -7,7 +10,6 @@ class TimeSeriesChannel:
         start,
         end,
         type="CONTINUOUS",
-        unit="uV",
         group="default",
         last_annotation=0,
         properties=None,
@@ -27,7 +29,6 @@ class TimeSeriesChannel:
         self.start = int(start)
         self.end = int(end)
 
-        self.unit = unit.strip()
         self.type = type.upper()
         self.group = group.strip()
         self.last_annotation = last_annotation
@@ -38,7 +39,7 @@ class TimeSeriesChannel:
             "name": self.name,
             "start": self.start,
             "end": self.end,
-            "unit": self.unit,
+            "unit": self.UNIT,
             "rate": self.rate,
             "type": self.type,
             "group": self.group,
@@ -53,11 +54,11 @@ class TimeSeriesChannel:
 
     @staticmethod
     def from_dict(channel, properties=None):
+        # Note: channel["unit"] is ignored - unit is always uV
         return TimeSeriesChannel(
             name=channel["name"],
             start=int(channel["start"]),
             end=int(channel["end"]),
-            unit=channel["unit"],
             rate=channel["rate"],
             type=channel.get("channelType", channel.get("type")),
             group=channel["group"],

--- a/processor/writer.py
+++ b/processor/writer.py
@@ -89,8 +89,8 @@ class TimeSeriesChunkWriter:
 
         file_name = "channel-{}_{}_{}{}".format(
             "{index:05d}".format(index=channel_index),
-            int(start_time * 1e6),
-            int(end_time * 1e6),
+            round(start_time * 1e6),
+            round(end_time * 1e6),
             TIME_SERIES_BINARY_FILE_EXTENSION,
         )
         file_path = os.path.join(output_dir, file_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def mock_electrical_series(sample_electrical_series_data, sample_timestamps):
     series.conversion = 1.0
     series.offset = 0.0
     series.channel_conversion = None
+    series.unit = "volts"
 
     # Mock electrodes table
     mock_electrodes = []

--- a/tests/test_timeseries_channel.py
+++ b/tests/test_timeseries_channel.py
@@ -15,7 +15,7 @@ class TestTimeSeriesChannelInit:
         assert channel.start == 1000000
         assert channel.end == 2000000
         assert channel.type == "CONTINUOUS"
-        assert channel.unit == "uV"
+        assert TimeSeriesChannel.UNIT == "uV"
         assert channel.group == "default"
         assert channel.last_annotation == 0
         assert channel.properties == []
@@ -30,7 +30,6 @@ class TestTimeSeriesChannelInit:
             start=500000,
             end=1500000,
             type="UNIT",
-            unit="  mV  ",
             group="  electrode_group  ",
             last_annotation=100,
             properties=[{"key": "value"}],
@@ -43,7 +42,7 @@ class TestTimeSeriesChannelInit:
         assert channel.start == 500000
         assert channel.end == 1500000
         assert channel.type == "UNIT"  # should be uppercased
-        assert channel.unit == "mV"  # should be stripped
+        assert TimeSeriesChannel.UNIT == "uV"  # unit is always uV
         assert channel.group == "electrode_group"  # should be stripped
         assert channel.last_annotation == 100
         assert channel.properties == [{"key": "value"}]
@@ -124,7 +123,7 @@ class TestTimeSeriesChannelFromDict:
         assert channel.name == "Channel 1"
         assert channel.start == 1000000
         assert channel.end == 2000000
-        assert channel.unit == "uV"
+        assert TimeSeriesChannel.UNIT == "uV"  # unit is always uV
         assert channel.rate == 30000.0
         assert channel.type == "CONTINUOUS"
         assert channel.group == "default"
@@ -281,7 +280,6 @@ class TestTimeSeriesChannelRoundTrip:
             start=500000,
             end=1500000,
             type="UNIT",
-            unit="mV",
             group="test_group",
             last_annotation=50,
             properties=[{"key": "value"}],
@@ -296,7 +294,7 @@ class TestTimeSeriesChannelRoundTrip:
         assert restored.start == original.start
         assert restored.end == original.end
         assert restored.type == original.type
-        assert restored.unit == original.unit
+        assert serialized["unit"] == "uV"  # unit is always uV in serialized output
         assert restored.group == original.group
         assert restored.last_annotation == original.last_annotation
         assert restored.properties == original.properties

--- a/tests/test_timeseries_client.py
+++ b/tests/test_timeseries_client.py
@@ -76,7 +76,7 @@ class TestTimeSeriesClientCreateChannel:
 
         client = TimeSeriesClient("https://api.test.com", mock_session_manager)
         channel = TimeSeriesChannel(
-            index=0, name="Ch1", rate=1000.0, start=0, end=1000, type="UNIT", unit="mV", group="test_group"
+            index=0, name="Ch1", rate=1000.0, start=0, end=1000, type="UNIT", group="test_group"
         )
 
         client.create_channel("pkg-123", channel)
@@ -86,7 +86,7 @@ class TestTimeSeriesClientCreateChannel:
         assert body["rate"] == 1000.0
         assert body["channelType"] == "UNIT"  # 'type' should be renamed to 'channelType'
         assert "type" not in body  # Original 'type' key should be removed
-        assert body["unit"] == "mV"
+        assert body["unit"] == "uV"  # unit is always uV
         assert body["group"] == "test_group"
 
     @responses.activate

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -34,9 +34,9 @@ class TestWriteChunk:
 
         TimeSeriesChunkWriter.write_chunk(chunk, start_time, end_time, 0, temp_output_dir)
 
-        # Check file was created
+        # Check file was created (use round() to match writer behavior)
         expected_filename = (
-            f"channel-00000_{int(start_time * 1e6)}_{int(end_time * 1e6)}{TIME_SERIES_BINARY_FILE_EXTENSION}"
+            f"channel-00000_{round(start_time * 1e6)}_{round(end_time * 1e6)}{TIME_SERIES_BINARY_FILE_EXTENSION}"
         )
         file_path = os.path.join(temp_output_dir, expected_filename)
         assert os.path.exists(file_path)
@@ -116,7 +116,7 @@ class TestWriteChannel:
         writer = TimeSeriesChunkWriter(session_start_time, temp_output_dir, 1000)
 
         channel = TimeSeriesChannel(
-            index=5, name="Test Channel", rate=30000.0, start=1000000, end=2000000, unit="mV", group="electrode_group"
+            index=5, name="Test Channel", rate=30000.0, start=1000000, end=2000000, group="electrode_group"
         )
 
         writer.write_channel(channel)
@@ -135,7 +135,6 @@ class TestWriteChannel:
             rate=30000.0,
             start=1000000,
             end=2000000,
-            unit="mV",
             type="CONTINUOUS",
             group="test_group",
             last_annotation=100,
@@ -153,7 +152,7 @@ class TestWriteChannel:
         assert data["rate"] == 30000.0
         assert data["start"] == 1000000
         assert data["end"] == 2000000
-        assert data["unit"] == "mV"
+        assert data["unit"] == "uV"  # unit is always uV
         assert data["type"] == "CONTINUOUS"
         assert data["group"] == "test_group"
         assert data["lastAnnotation"] == 100


### PR DESCRIPTION
## Description
From the NWB docs: https://github.com/NeurodataWithoutBorders/nwb-schema/blob/d65d42257003543c569ea7ac0cd6d7aee01c88d6/core/nwb.ecephys.yaml#L35-L42 , applying the conversion factors necessarily returns data in volts, not whatever unit it was actually stored in.

Also round instead of flooring timestamps for slightly more accurate values ranges.